### PR TITLE
Reintroduce glass navigation and polish landing aesthetics

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,23 +1,21 @@
 import Header from '@/components/Header';
 import Hero from '@/components/Hero';
 import ModeShowcase from '@/components/ModeShowcase';
-import ExperienceSection from '@/components/ExperienceSection';
 import DownloadSection from '@/components/DownloadSection';
 import Footer from '@/components/Footer';
 import GlobeStage from '@/components/GlobeStage';
 
 export default function Home() {
   return (
-    <div className="relative flex min-h-screen flex-col overflow-hidden bg-[#040915] text-white">
+    <div className="relative flex min-h-screen flex-col bg-[#040915] text-white">
       <div aria-hidden className="pointer-events-none fixed inset-0 -z-20">
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(22,53,138,0.7)_0%,rgba(9,18,42,0.82)_40%,rgba(2,7,20,0.95)_75%,rgba(1,4,14,1)_100%)]" />
       </div>
       <GlobeStage />
       <Header />
-      <main className="relative z-10 flex-1 space-y-32 px-4 pb-32 pt-28 sm:px-8 lg:px-16 lg:pb-40">
+      <main className="relative z-10 flex-1 space-y-24 px-4 pb-24 pt-32 sm:px-8 lg:px-16 lg:pb-32">
         <Hero />
         <ModeShowcase />
-        <ExperienceSection />
         <DownloadSection />
       </main>
       <Footer />

--- a/components/DownloadSection.tsx
+++ b/components/DownloadSection.tsx
@@ -2,45 +2,39 @@ import Link from 'next/link';
 
 export default function DownloadSection() {
   return (
-    <section id="download" className="relative">
-      <div className="mx-auto max-w-5xl overflow-hidden rounded-[40px] border border-white/10 bg-gradient-to-br from-accent/20 via-white/10 to-transparent p-[1px]">
-        <div className="grid gap-8 rounded-[40px] bg-surface/70 px-8 py-10 backdrop-blur xl:grid-cols-[2fr_1fr] xl:items-center xl:px-12">
-          <div className="space-y-4">
-            <p className="text-sm uppercase tracking-[0.4em] text-white/60">Available soon</p>
-            <h2 className="text-3xl font-semibold text-white md:text-4xl">Reserve your seat on the Atlas waitlist.</h2>
-            <p className="text-base text-white/70">
-              Get early access, exclusive icon packs, and behind-the-scenes updates on how we crafted the most beautiful world map quiz for iPhone.
-            </p>
-            <form className="mt-6 flex flex-col gap-3 sm:flex-row">
-              <input
-                type="email"
-                placeholder="Email address"
-                className="h-12 flex-1 rounded-full border border-white/10 bg-white/5 px-5 text-sm text-white placeholder:text-white/40 focus:border-white/30 focus:outline-none"
-              />
-              <button
-                type="submit"
-                className="h-12 rounded-full bg-white px-6 text-sm font-semibold text-surface shadow-[0_20px_44px_rgba(8,12,24,0.35)] transition hover:-translate-y-0.5"
-              >
-                Join waitlist
-              </button>
-            </form>
-          </div>
-          <div className="flex flex-col gap-4 rounded-[28px] border border-white/15 bg-white/[0.08] p-6 text-sm text-white/70">
-            <div>
-              <div className="text-xs uppercase tracking-[0.3em] text-white/50">What you get</div>
-              <ul className="mt-3 space-y-2 text-sm text-white/80">
-                <li>• Day-one notification when Atlas launches</li>
-                <li>• Access to the Atlas Founders community</li>
-                <li>• Exclusive wallpapers from every continent</li>
-              </ul>
-            </div>
-            <Link href="https://apps.apple.com" className="inline-flex items-center gap-2 text-white/70 transition hover:text-white">
-              Preview on the App Store
-              <svg className="h-4 w-4" viewBox="0 0 16 16" fill="none" aria-hidden>
-                <path d="M4 12l6-6M10 12V6H4" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
-              </svg>
-            </Link>
-          </div>
+    <section id="waitlist" className="relative">
+      <div className="relative mx-auto max-w-4xl overflow-hidden rounded-[44px] border border-white/12 bg-white/[0.04] p-10 text-white/75 shadow-[0_70px_140px_-70px_rgba(8,12,24,0.85)] backdrop-blur-2xl">
+        <div aria-hidden className="pointer-events-none absolute inset-0 -z-10">
+          <div className="absolute inset-0 bg-gradient-to-br from-white/[0.08] via-transparent to-white/[0.02]" />
+          <div className="absolute left-[-15%] top-[-20%] h-64 w-64 rounded-full bg-accent/25 blur-[140px]" />
+          <div className="absolute right-[-10%] bottom-[-30%] h-72 w-72 rounded-full bg-aurora/25 blur-[160px]" />
+          <div className="absolute inset-0 bg-grid-faint bg-[length:150px_150px] opacity-20" />
+        </div>
+        <div className="space-y-5">
+          <p className="text-xs uppercase tracking-[0.45em] text-white/45">Early access</p>
+          <h2 className="text-3xl font-semibold text-white md:text-4xl">Be first in line for Atlas.</h2>
+          <p className="max-w-2xl text-base leading-relaxed text-white/70">
+            Join the waitlist for a calm cadence of updates and a launch invite the moment Atlas is ready.
+          </p>
+          <form className="mt-6 flex flex-col gap-3 sm:flex-row">
+            <input
+              type="email"
+              placeholder="Email address"
+              className="h-12 flex-1 rounded-full border border-white/15 bg-white/10 px-5 text-sm text-white placeholder:text-white/40 focus:border-white/40 focus:outline-none"
+            />
+            <button
+              type="submit"
+              className="h-12 rounded-full bg-white px-6 text-sm font-semibold text-surface shadow-[0_24px_44px_rgba(15,23,42,0.3)] transition hover:-translate-y-0.5"
+            >
+              Join the waitlist
+            </button>
+          </form>
+          <Link href="https://apps.apple.com" className="inline-flex items-center gap-2 text-sm text-white/70 transition hover:text-white">
+            Preview on the App Store
+            <svg className="h-4 w-4" viewBox="0 0 16 16" fill="none" aria-hidden>
+              <path d="M4 12l6-6M10 12V6H4" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </Link>
         </div>
       </div>
     </section>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -2,32 +2,21 @@ import Link from 'next/link';
 
 export default function Footer() {
   return (
-    <footer className="border-t border-white/10 bg-surface/70">
-      <div className="mx-auto flex max-w-6xl flex-col gap-6 px-6 py-10 text-sm text-white/60 md:flex-row md:items-center md:justify-between">
-        <div className="flex items-center gap-3">
-          <span className="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-accent via-white/40 to-aurora text-surface">
-            <span className="text-lg font-semibold">A</span>
-          </span>
-          <div>
-            <p className="text-white/90">Atlas</p>
-            <p>Crafted for curious explorers everywhere.</p>
-          </div>
-        </div>
+    <footer className="border-t border-white/10 bg-white/[0.02] backdrop-blur">
+      <div className="mx-auto flex max-w-6xl flex-col gap-4 px-6 py-8 text-sm text-white/55 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-white/80">Atlas</p>
         <div className="flex flex-wrap items-center gap-4">
+          <Link href="#overview" className="transition hover:text-white">
+            Overview
+          </Link>
           <Link href="#modes" className="transition hover:text-white">
             Modes
           </Link>
-          <Link href="#experience" className="transition hover:text-white">
-            Experience
-          </Link>
-          <Link href="#download" className="transition hover:text-white">
-            Download
-          </Link>
-          <Link href="mailto:hello@atlas.app" className="transition hover:text-white">
-            Contact
+          <Link href="#waitlist" className="transition hover:text-white">
+            Updates
           </Link>
         </div>
-        <p className="text-xs text-white/40">© {new Date().getFullYear()} Atlas Labs. All rights reserved.</p>
+        <p className="text-xs text-white/35">© {new Date().getFullYear()} Atlas Labs</p>
       </div>
     </footer>
   );

--- a/components/GlobeStage.tsx
+++ b/components/GlobeStage.tsx
@@ -13,7 +13,7 @@ const InteractiveGlobe = dynamic(() => import('./InteractiveGlobe'), {
 
 export default function GlobeStage() {
   return (
-    <div className="fixed inset-0 z-0 flex items-center justify-center">
+    <div className="pointer-events-none fixed inset-0 z-0 flex items-center justify-center">
       <div aria-hidden className="pointer-events-none absolute inset-0">
         <div className="absolute inset-x-0 top-[-40%] h-[720px] bg-gradient-to-b from-white/10 via-transparent to-transparent blur-[220px]" />
         <div className="absolute inset-x-0 bottom-[-30%] h-[560px] bg-gradient-to-t from-[#031027]/80 via-transparent to-transparent blur-[220px]" />

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,16 +1,16 @@
 import Link from 'next/link';
 
 const navItems = [
+  { href: '#overview', label: 'Overview' },
   { href: '#modes', label: 'Game Modes' },
-  { href: '#experience', label: 'Experience' },
-  { href: '#download', label: 'Download' }
+  { href: '#waitlist', label: 'Updates' }
 ];
 
 export default function Header() {
   return (
     <header className="fixed inset-x-0 top-0 z-50 flex justify-center px-4 pt-6">
       <div className="glass flex w-full max-w-6xl items-center justify-between rounded-full px-5 py-3 shadow-glow transition-all duration-500 ease-out hover:shadow-[0_0_160px_rgba(124,134,255,0.24)]">
-        <Link href="#" className="flex items-center gap-2 text-sm font-semibold tracking-tight">
+        <Link href="#overview" className="flex items-center gap-2 text-sm font-semibold tracking-tight text-white">
           <span className="flex h-9 w-9 items-center justify-center rounded-full bg-gradient-to-br from-accent via-white/40 to-aurora text-surface shadow-inner">
             <svg viewBox="0 0 32 32" fill="none" aria-hidden className="h-5 w-5 text-surface">
               <defs>
@@ -38,7 +38,7 @@ export default function Header() {
         </nav>
         <div className="flex items-center gap-3">
           <Link
-            href="#download"
+            href="#waitlist"
             className="hidden rounded-full border border-white/20 px-4 py-2 text-sm text-white/70 transition hover:border-white/40 hover:text-white md:inline-flex"
           >
             Join the waitlist

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,240 +1,77 @@
 'use client';
 
 import Link from 'next/link';
-import { type CSSProperties, useEffect, useRef } from 'react';
 
-type SpotlightStyle = CSSProperties & {
-  '--spotlight-x'?: string;
-  '--spotlight-y'?: string;
-};
-
-const highlights = [
+const essentials = [
   {
-    title: 'Lightning Recall',
-    description:
-      'Speed rounds sharpen your memory with beautifully legible typography tuned for focus across Retina and ProMotion displays.',
-    accent: 'from-accent/80 via-accent to-white/80'
+    title: 'Three focused game modes',
+    description: 'Name, locate, and match the world’s countries without distraction.'
   },
   {
-    title: 'Immersive Touch',
-    description:
-      'Handcrafted multi-touch hit zones glide across the sphere without pixelated seams, so every swipe feels like liquid metal.',
-    accent: 'from-aurora/70 via-aurora to-white/80'
+    title: 'Built for touch',
+    description: 'Fluid gestures and gentle motion keep the globe in constant flow.'
   },
   {
-    title: 'Sonic Atmosphere',
-    description:
-      'Spatial soundscapes swell as you travel, matching every discovery with an orchestral score tuned for AirPods and beyond.',
-    accent: 'from-amber/70 via-amber to-white/80'
+    title: 'Play in minutes',
+    description: 'Quick sessions adapt to the time you have, from a spare moment to a streak.'
   }
-];
-
-const narratives = [
-  {
-    heading: 'Cartography for clarity',
-    body: 'Every border is redrawn in high fidelity, then tinted with lush emerald hues so countries feel alive yet perfectly legible.'
-  },
-  {
-    heading: 'A rhythm designed to flow',
-    body: 'Progression, streaks, and challenges cascade as you scroll—each panel gently overlapping the next so the story never breaks.'
-  }
-];
-
-const timeline = [
-  {
-    step: '01',
-    title: 'Orbit in real time',
-    copy: 'Pan, tilt, and spin with buttery-smooth inertia. Adaptive damping keeps motion stable even on smaller devices.'
-  },
-  {
-    step: '02',
-    title: 'Discover the unexpected',
-    copy: 'Micro-animations illuminate capitals, coastlines, and achievements the moment you unlock them.'
-  },
-  {
-    step: '03',
-    title: 'Share your mastery',
-    copy: 'One tap exports gorgeous session summaries ready for Messages, social, or your personal study journal.'
-  }
-];
-
-const metrics = [
-  { label: 'Average daily session', value: '6m 12s' },
-  { label: 'Countries rendered', value: '195' },
-  { label: 'Star particles', value: '60k adaptive' },
-  { label: 'Supported devices', value: 'iPhone + iPad + Mac' }
 ];
 
 export default function Hero() {
-  const highlightRefs = useRef<(HTMLDivElement | null)[]>([]);
-
-  useEffect(() => {
-    const nodes = highlightRefs.current;
-    const cleanups = nodes.map((node) => {
-      if (!node) {
-        return () => {};
-      }
-
-      const setSpotlight = (event: PointerEvent) => {
-        const rect = node.getBoundingClientRect();
-        const x = ((event.clientX - rect.left) / rect.width) * 100;
-        const y = ((event.clientY - rect.top) / rect.height) * 100;
-        node.style.setProperty('--spotlight-x', `${x}%`);
-        node.style.setProperty('--spotlight-y', `${y}%`);
-      };
-
-      const resetSpotlight = () => {
-        node.style.setProperty('--spotlight-x', '50%');
-        node.style.setProperty('--spotlight-y', '50%');
-      };
-
-      node.addEventListener('pointermove', setSpotlight);
-      node.addEventListener('pointerleave', resetSpotlight);
-      node.addEventListener('pointerup', resetSpotlight);
-
-      return () => {
-        node.removeEventListener('pointermove', setSpotlight);
-        node.removeEventListener('pointerleave', resetSpotlight);
-        node.removeEventListener('pointerup', resetSpotlight);
-      };
-    });
-
-    return () => {
-      cleanups.forEach((cleanup) => cleanup());
-    };
-  }, []);
-
   return (
     <section
       id="overview"
-      className="relative z-10 mx-auto flex min-h-screen w-full max-w-6xl flex-col justify-center gap-16 px-4 pb-28 pt-28 sm:px-6 lg:px-8"
+      className="relative mx-auto w-full max-w-5xl overflow-hidden rounded-[48px] border border-white/10 bg-white/[0.04] p-10 text-white/75 shadow-[0_70px_140px_-70px_rgba(8,12,24,0.85)] backdrop-blur-2xl"
     >
-      <div className="flex flex-col gap-10 lg:flex-row lg:items-end">
-        <div className="space-y-8 lg:max-w-2xl">
-          <div className="inline-flex w-fit items-center gap-2 rounded-full border border-white/15 bg-white/10 px-4 py-2 text-sm text-white/70 backdrop-blur">
-            <span className="h-2 w-2 rounded-full bg-aurora" />
-            Early access now open
-          </div>
-          <div className="space-y-6">
-            <h1 className="text-4xl font-semibold leading-tight tracking-tight md:text-6xl">
-              Command the world’s knowledge from a living, responsive sphere.
-            </h1>
-            <p className="max-w-xl text-lg text-white/70">
-              Atlas blends artistry and precision so you can effortlessly explore every border, capital, and flag. Learn faster,
-              compete smarter, and fall in love with the world again.
-            </p>
-          </div>
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-            <Link
-              href="https://apps.apple.com"
-              className="inline-flex items-center justify-center gap-3 rounded-full bg-white px-6 py-3 text-base font-semibold text-surface shadow-[0_24px_44px_rgba(15,23,42,0.35)] transition hover:-translate-y-0.5"
-            >
-              <span className="text-xl"></span>
-              Download for iOS
-            </Link>
-            <Link
-              href="#download"
-              className="inline-flex items-center justify-center gap-2 rounded-full border border-white/25 bg-white/5 px-6 py-3 text-base text-white/80 backdrop-blur transition hover:border-white/40 hover:text-white"
-            >
-              Watch the trailer
-              <svg className="h-4 w-4" viewBox="0 0 16 16" fill="none" aria-hidden>
-                <path d="M5.5 4l6 4-6 4V4z" fill="currentColor" />
-              </svg>
-            </Link>
-          </div>
-          <dl className="grid grid-cols-2 gap-4 text-sm text-white/60 sm:max-w-lg">
-            {metrics.map((metric) => (
-              <div key={metric.label} className="rounded-2xl border border-white/10 bg-white/[0.05] p-4 backdrop-blur">
-                <dt className="text-xs uppercase tracking-[0.35em] text-white/45">{metric.label}</dt>
-                <dd className="mt-2 text-lg font-semibold text-white">{metric.value}</dd>
-              </div>
-            ))}
-          </dl>
+      <div aria-hidden className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-white/[0.03]" />
+        <div className="absolute left-1/2 top-[-10%] h-80 w-80 -translate-x-1/2 rounded-full bg-accent/25 blur-[140px]" />
+        <div className="absolute bottom-[-25%] right-[-10%] h-80 w-80 rounded-full bg-aurora/25 blur-[160px]" />
+        <div className="absolute inset-0 bg-grid-faint bg-[length:140px_140px] opacity-25" />
+      </div>
+      <div className="space-y-7">
+        <span className="inline-flex w-fit items-center gap-2 rounded-full border border-white/15 bg-white/10 px-4 py-1.5 text-[11px] uppercase tracking-[0.48em] text-white/70">
+          Atlas
+        </span>
+        <div className="space-y-5">
+          <h1 className="max-w-3xl text-4xl font-semibold leading-tight tracking-tight text-white md:text-5xl">
+            Geography, reimagined with quiet precision.
+          </h1>
+          <p className="max-w-2xl text-lg leading-relaxed text-white/70">
+            Atlas focuses on the essentials — three refined modes, fluid motion, and a globe that responds instantly. It’s a calm invitation to know the world by heart.
+          </p>
         </div>
-        <div className="relative isolate flex w-full max-w-sm flex-col gap-6 overflow-hidden rounded-[36px] border border-white/10 bg-white/[0.07] p-8 text-sm text-white/75 shadow-[0_40px_160px_-70px_rgba(5,11,24,0.95)] backdrop-blur">
-          <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.16),transparent_55%)]" />
-          <div>
-            <p className="text-xs uppercase tracking-[0.4em] text-white/40">Live Globe Feed</p>
-            <p className="mt-3 text-base text-white">
-              The hero globe anchors the entire site. Scroll and the narrative glides around it, revealing modes, challenges, and
-              soundscapes like constellations in motion.
-            </p>
-          </div>
-          <div className="flex flex-col gap-4 text-xs uppercase tracking-[0.3em] text-white/55">
-            <span className="inline-flex items-center gap-3 rounded-full border border-white/15 bg-white/5 px-3 py-2">
-              <span className="h-2 w-2 rounded-full bg-aurora" />
-              Live preview synched
-            </span>
-            <span className="inline-flex items-center gap-3 rounded-full border border-white/15 bg-white/5 px-3 py-2">
-              <span className="h-2 w-2 rounded-full bg-accent" />
-              Motion aware physics
-            </span>
-          </div>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <Link
+            href="#waitlist"
+            className="inline-flex items-center justify-center gap-3 rounded-full bg-white px-6 py-3 text-base font-semibold text-surface shadow-[0_24px_44px_rgba(15,23,42,0.25)] transition hover:-translate-y-0.5"
+          >
+            Join the waitlist
+          </Link>
+          <Link
+            href="#modes"
+            className="inline-flex items-center justify-center gap-2 rounded-full border border-white/25 px-6 py-3 text-base text-white/80 transition hover:border-white/40 hover:text-white"
+          >
+            Discover the modes
+            <svg className="h-4 w-4" viewBox="0 0 16 16" fill="none" aria-hidden>
+              <path d="M6 4l4 4-4 4" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </Link>
         </div>
       </div>
-      <div className="-mx-4 flex snap-x snap-mandatory gap-4 overflow-x-auto pb-6 scrollbar-hidden sm:mx-0 sm:grid sm:snap-none sm:grid-cols-3 sm:gap-6 sm:overflow-visible">
-        {highlights.map((highlight, index) => (
+      <div className="mt-10 grid gap-4 sm:grid-cols-3">
+        {essentials.map((item) => (
           <div
-            key={highlight.title}
-            ref={(el) => {
-              highlightRefs.current[index] = el;
-            }}
-            style={{ '--spotlight-x': '50%', '--spotlight-y': '50%' } as SpotlightStyle}
-            className="group relative min-w-[240px] snap-center overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-6 transition duration-500 hover:-translate-y-1 hover:border-white/30 hover:shadow-[0_30px_80px_rgba(18,32,59,0.45)] sm:min-w-0"
+            key={item.title}
+            className="group relative overflow-hidden rounded-[28px] border border-white/12 bg-white/[0.03] p-5 transition duration-500 hover:-translate-y-1"
           >
-            <span
-              className={`pointer-events-none absolute inset-0 opacity-60 blur-2xl transition duration-500 group-hover:opacity-90 bg-gradient-to-br ${highlight.accent}`}
-            />
-            <span
-              className="pointer-events-none absolute inset-[-30%] opacity-0 transition duration-700 group-hover:opacity-100"
-              style={{
-                background: 'radial-gradient(circle at var(--spotlight-x) var(--spotlight-y), rgba(255,255,255,0.28), transparent 65%)'
-              }}
-            />
-            <div className="relative space-y-3">
-              <div className="text-sm font-semibold text-white/90">{highlight.title}</div>
-              <p className="text-xs leading-relaxed text-white/65">{highlight.description}</p>
+            <div className="absolute inset-px rounded-[26px] bg-gradient-to-br from-white/15 via-transparent to-transparent opacity-0 transition duration-500 group-hover:opacity-100" />
+            <div className="relative space-y-2">
+              <h2 className="text-sm font-semibold text-white">{item.title}</h2>
+              <p className="text-sm leading-relaxed text-white/65">{item.description}</p>
             </div>
           </div>
         ))}
-      </div>
-      <div className="grid gap-10 rounded-[44px] border border-white/10 bg-white/[0.06] p-10 text-white/75 shadow-[0_60px_160px_-60px_rgba(5,12,26,0.85)] backdrop-blur lg:grid-cols-[1.2fr_1fr]">
-        <div className="space-y-8">
-          <div className="space-y-3">
-            <p className="text-xs uppercase tracking-[0.4em] text-white/40">Design Ethos</p>
-            <h2 className="text-2xl font-semibold text-white md:text-3xl">Crafted like an Apple flagship experience.</h2>
-            <p className="text-sm leading-relaxed">
-              Sections cascade beneath the globe with gentle parallax, creating a cinematic rhythm you can feel on desktop and mobile alike.
-            </p>
-          </div>
-          <div className="grid gap-6 md:grid-cols-2">
-            {narratives.map((item) => (
-              <div key={item.heading} className="rounded-3xl border border-white/10 bg-white/[0.05] p-6">
-                <h3 className="text-lg font-semibold text-white">{item.heading}</h3>
-                <p className="mt-3 text-sm leading-relaxed text-white/70">{item.body}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-        <div className="relative flex flex-col justify-between gap-6 rounded-[32px] border border-white/10 bg-gradient-to-br from-white/10 via-transparent to-white/5 p-8 text-sm text-white/70">
-          <div className="space-y-5">
-            <p className="text-xs uppercase tracking-[0.35em] text-white/40">Scroll Story</p>
-            <p className="text-base text-white">
-              Follow the arc from first touch to global mastery. Each beat unlocks another layer of Atlas without ever losing sight of the cosmos behind it.
-            </p>
-          </div>
-          <ol className="space-y-4 text-white/60">
-            {timeline.map((item) => (
-              <li key={item.step} className="flex gap-4 rounded-2xl border border-white/10 bg-white/[0.04] p-4">
-                <span className="text-xs font-semibold uppercase tracking-[0.35em] text-white/45">{item.step}</span>
-                <div className="space-y-1">
-                  <p className="text-sm font-semibold text-white">{item.title}</p>
-                  <p className="text-xs leading-relaxed">{item.copy}</p>
-                </div>
-              </li>
-            ))}
-          </ol>
-        </div>
       </div>
     </section>
   );

--- a/components/InteractiveGlobe.tsx
+++ b/components/InteractiveGlobe.tsx
@@ -308,7 +308,7 @@ export default function InteractiveGlobe({ className }: InteractiveGlobeProps = 
     const globeGroup = new THREE.Group();
     scene.add(globeGroup);
 
-    const earthGeometry = new THREE.SphereGeometry(GLOBE_RADIUS, 200, 200);
+    const earthGeometry = new THREE.SphereGeometry(GLOBE_RADIUS, 128, 128);
     const earthMaterial = new THREE.MeshStandardMaterial({
       color: new THREE.Color('#08346a'),
       roughness: 0.5,
@@ -332,7 +332,7 @@ export default function InteractiveGlobe({ className }: InteractiveGlobeProps = 
     const earthMesh = new THREE.Mesh(earthGeometry, earthMaterial);
     globeGroup.add(earthMesh);
 
-    const atmosphereGeometry = new THREE.SphereGeometry(ATMOSPHERE_RADIUS, 160, 160);
+    const atmosphereGeometry = new THREE.SphereGeometry(ATMOSPHERE_RADIUS, 96, 96);
     const atmosphereMaterial = new THREE.MeshBasicMaterial({
       color: new THREE.Color('#6bb8ff'),
       transparent: true,
@@ -343,8 +343,8 @@ export default function InteractiveGlobe({ className }: InteractiveGlobeProps = 
     globeGroup.add(atmosphere);
 
     const { width: initialWidth, height: initialHeight } = container.getBoundingClientRect();
-    const estimatedArea = Math.max(initialWidth * initialHeight, 560 * 560);
-    const starCount = Math.round(THREE.MathUtils.clamp(estimatedArea / 180, 900, 2200));
+    const estimatedArea = Math.max(initialWidth * initialHeight, 480 * 480);
+    const starCount = Math.round(THREE.MathUtils.clamp(estimatedArea / 260, 420, 1200));
     const starPositions = new Float32Array(starCount * 3);
     const starColors = new Float32Array(starCount * 3);
 

--- a/components/ModeShowcase.tsx
+++ b/components/ModeShowcase.tsx
@@ -1,56 +1,76 @@
 const modes = [
   {
     name: 'Name the Nation',
+    tagline: 'Rapid recall',
     description:
-      'Listen for subtle audio cues and race the clock to type or speak each country with zero friction — even the trickiest territories.',
-    detail: 'Adaptive hints keep you on pace while preserving the thrill of mastery.',
-    accent: 'from-accent/70 via-accent/40 to-transparent'
+      'Cinematic audio prompts and immediate feedback keep you on tempo while you type every country.',
+    gradient: 'linear-gradient(135deg, rgba(152,185,255,0.55) 0%, rgba(42,65,168,0.45) 45%, rgba(8,13,31,0) 90%)',
+    beam: 'linear-gradient(120deg, rgba(124,134,255,0.45) 0%, rgba(8,13,31,0) 70%)',
+    accent: '#dbe5ff'
   },
   {
     name: 'Find it on the Map',
+    tagline: 'Spatial mastery',
     description:
-      'A beautiful 3D-inspired map invites you to pinch, zoom, and tap to locate nations. Each success paints the globe in luminous gradients.',
-    detail: 'Haptic feedback and spatial audio bring every coastline to life.',
-    accent: 'from-aurora/70 via-aurora/40 to-transparent'
+      'A touch-first globe glides beneath your fingertips so you can pinpoint nations with effortless precision.',
+    gradient: 'linear-gradient(135deg, rgba(123,241,214,0.55) 0%, rgba(18,107,92,0.45) 45%, rgba(6,14,26,0) 90%)',
+    beam: 'linear-gradient(120deg, rgba(85,235,211,0.4) 0%, rgba(6,14,26,0) 70%)',
+    accent: '#d6fff5'
   },
   {
     name: 'Match the Flag',
+    tagline: 'Visual memory',
     description:
-      'Discover the stories behind every flag with dynamic color spaces tailored for OLED. Compare, memorize, and master the emblems of the world.',
-    detail: 'Unlock collectible wallpapers as you build your streak.',
-    accent: 'from-amber/80 via-amber/40 to-transparent'
+      'Curated palettes and tactile animations help you lock in every emblem and the story each design carries.',
+    gradient: 'linear-gradient(135deg, rgba(255,201,138,0.55) 0%, rgba(196,106,27,0.42) 45%, rgba(12,8,0,0) 90%)',
+    beam: 'linear-gradient(120deg, rgba(249,168,77,0.38) 0%, rgba(12,8,0,0) 70%)',
+    accent: '#ffe9d0'
   }
 ];
 
 export default function ModeShowcase() {
   return (
     <section id="modes" className="relative">
-      <div className="mx-auto flex max-w-6xl flex-col gap-10">
-        <div className="space-y-4">
-          <p className="text-sm uppercase tracking-[0.4em] text-white/40">Game Modes</p>
-          <h2 className="max-w-3xl text-3xl font-semibold leading-tight text-white md:text-4xl">
-            Three distinctive challenges. One unforgettable geography experience.
-          </h2>
-          <p className="max-w-2xl text-base text-white/70">
-            Each mode in Atlas is tuned to sharpen a different part of your memory — from names to locations to iconography. Rotate
-            between them for a complete mental map of our planet.
+      <div className="relative mx-auto flex max-w-6xl flex-col gap-12 overflow-hidden rounded-[48px] border border-white/10 bg-white/[0.03] p-10 shadow-[0_60px_140px_-80px_rgba(8,12,24,0.85)] backdrop-blur-2xl">
+        <div aria-hidden className="pointer-events-none absolute inset-0 -z-10">
+          <div className="absolute inset-0 bg-gradient-to-br from-white/[0.08] via-transparent to-white/[0.02]" />
+          <div className="absolute -left-24 top-16 h-80 w-80 rounded-full bg-accent/20 blur-[160px]" />
+          <div className="absolute -right-16 bottom-10 h-80 w-80 rounded-full bg-aurora/20 blur-[160px]" />
+          <div className="absolute inset-0 bg-grid-faint bg-[length:160px_160px] opacity-20" />
+        </div>
+        <div className="space-y-4 text-white/70">
+          <p className="text-xs uppercase tracking-[0.45em] text-white/45">Game Modes</p>
+          <h2 className="max-w-3xl text-3xl font-semibold text-white md:text-4xl">Three elegant challenges, tuned for flow.</h2>
+          <p className="max-w-2xl text-base leading-relaxed">
+            Each mode isolates a different sense of geography — names, locations, and icons — so you can move effortlessly between them and master the planet with intention.
           </p>
         </div>
         <div className="grid gap-6 lg:grid-cols-3">
           {modes.map((mode) => (
             <article
               key={mode.name}
-              className="group relative overflow-hidden rounded-[28px] border border-white/10 bg-white/[0.05] p-6 shadow-card transition duration-500 hover:-translate-y-2 hover:border-white/30"
+              className="group relative overflow-hidden rounded-[36px] border border-white/12 bg-white/[0.04] p-7 transition duration-500 hover:-translate-y-2 hover:border-white/30"
             >
-              <div className={`absolute inset-0 bg-gradient-to-br ${mode.accent} opacity-0 transition duration-500 group-hover:opacity-80`} />
-              <div className="relative space-y-4">
-                <div className="inline-flex items-center rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs uppercase tracking-widest text-white/70">
-                  Elite mode
-                </div>
+              <div
+                aria-hidden
+                className="absolute inset-px rounded-[32px] opacity-0 transition duration-500 group-hover:opacity-100"
+                style={{ background: mode.gradient }}
+              />
+              <div
+                aria-hidden
+                className="absolute left-[-20%] top-[10%] h-48 w-48 rounded-full opacity-0 blur-[140px] transition duration-500 group-hover:opacity-100"
+                style={{ background: mode.beam }}
+              />
+              <div className="relative flex h-full flex-col gap-5 text-white/70">
+                <span
+                  className="inline-flex w-fit items-center gap-2 rounded-full border border-white/15 bg-white/10 px-3 py-1 text-[10px] uppercase tracking-[0.5em]"
+                  style={{ color: mode.accent }}
+                >
+                  {mode.tagline}
+                </span>
                 <h3 className="text-2xl font-semibold text-white">{mode.name}</h3>
-                <p className="text-sm leading-relaxed text-white/70">{mode.description}</p>
-                <p className="text-sm text-white/50">{mode.detail}</p>
-                <div className="pt-4 text-xs uppercase tracking-[0.3em] text-white/50">Built for Daily Play</div>
+                <p className="text-sm leading-relaxed">{mode.description}</p>
+                <div className="mt-auto pt-2 text-xs uppercase tracking-[0.35em] text-white/45">Designed for daily play</div>
               </div>
             </article>
           ))}


### PR DESCRIPTION
## Summary
- restore the glassmorphic navigation bar with the Atlas mark and streamlined anchors
- elevate the hero, mode showcase, and waitlist sections with premium gradients and refined typography
- enrich each game mode card with tailored accents and hover lighting for an elegant presentation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de5c5e8cb08320929e26cffb7716d2